### PR TITLE
Require nova-utils to avoid missing nova--get-local

### DIFF
--- a/nova-eldoc.el
+++ b/nova-eldoc.el
@@ -31,6 +31,8 @@
 
 ;;; Code:
 
+(require 'nova-utils)
+
 (unless (require 'eldoc-box nil t)
   (message "eldoc-box must be installed in order to use nova-eldoc"))
 


### PR DESCRIPTION
The nova-doc uses `nova--get-local` in nova-utils but does not require the script.